### PR TITLE
Add "--log-file" option

### DIFF
--- a/pysen_ls/__main__.py
+++ b/pysen_ls/__main__.py
@@ -1,16 +1,17 @@
 import argparse
 import logging
+from typing import Optional
 
 from .server import ConnectionMethod, Server
 
 _logger = logging.getLogger(__name__)
 
 
-def setup_logger(log_file: str) -> None:
+def setup_logger(log_file: Optional[str]) -> None:
     if log_file:
         handler = logging.FileHandler(log_file, mode="w")
     else:
-        handler = logging.StreamHandler()
+        handler = logging.NullHandler()
 
     handler.setLevel(logging.INFO)
 

--- a/pysen_ls/__main__.py
+++ b/pysen_ls/__main__.py
@@ -52,7 +52,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--log-file",
-        help="redirect logs to the given file instead of writing to stderr.",
+        help="Save logs to the given file.",
     )
     args = parser.parse_args()
 

--- a/pysen_ls/__main__.py
+++ b/pysen_ls/__main__.py
@@ -14,7 +14,7 @@ def setup_logger() -> None:
     package_logger.addHandler(handler)
     package_logger.setLevel(logging.INFO)
 
-    # NOTE: To suppress warnings like `Ignoring notification for unknown method`
+    # NOTE: To suppress warnings like `Ignoring notification for unknown method`  # NOQA
     pygls_logger = logging.getLogger("pygls")
     pygls_logger.setLevel(logging.ERROR)
 

--- a/pysen_ls/__main__.py
+++ b/pysen_ls/__main__.py
@@ -6,8 +6,12 @@ from .server import ConnectionMethod, Server
 _logger = logging.getLogger(__name__)
 
 
-def setup_logger() -> None:
-    handler = logging.FileHandler("pysen_ls.log", mode="w")
+def setup_logger(log_file: str) -> None:
+    if log_file:
+        handler = logging.FileHandler(log_file, mode="w")
+    else:
+        handler = logging.StreamHandler()
+
     handler.setLevel(logging.INFO)
 
     package_logger = logging.getLogger("pysen_ls")
@@ -20,7 +24,6 @@ def setup_logger() -> None:
 
 
 def main() -> None:
-    setup_logger()
     parser = argparse.ArgumentParser("pysen-ls")
     method_options = parser.add_mutually_exclusive_group(required=True)
     method_options.add_argument(
@@ -47,7 +50,13 @@ def main() -> None:
         default=3746,
         help="Port number for the tcp server. Only works with --tcp.",
     )
+    parser.add_argument(
+        "--log-file",
+        help="redirect logs to the given file instead of writing to stderr.",
+    )
     args = parser.parse_args()
+
+    setup_logger(args.log_file)
 
     server = Server(args.method, args.host, args.port)
     server.start()


### PR DESCRIPTION
Close https://github.com/bonprosoft/pysen-ls/issues/2

## Description

If an option is specified, write to the "file", if no option is specified, output to the "console". 🙇

## DEMO

![pysen-ls-pr](https://user-images.githubusercontent.com/188642/114477983-3ff42a80-9c38-11eb-84bb-6925e7264481.gif)

## Note

There is a language server called [jedi-language-server](https://github.com/pappasam/jedi-language-server) that uses `pygls`.

I used the "--log-file" option of jedi-language-server as a reference.

I don't think it will have any negative impact on the behavior of the language server.